### PR TITLE
feat: Allows playing song preview, along with custom controls

### DIFF
--- a/app/containers/ITunes/components/AlbumCard/index.js
+++ b/app/containers/ITunes/components/AlbumCard/index.js
@@ -35,8 +35,13 @@ const CustomT = styled(T)`
 `;
 export const AlbumCard = ({ artworkUrl100, trackName, trackExplicitness, artistName, index, musicPlayer }) => {
   return (
-    <CustomCard span={6} data-testid="album-card" onClick={() => musicPlayer(index)}>
-      <CustomImg src={artworkUrl100} borderRadius={20} />
+    <CustomCard span={6} data-testid="album-card">
+      <CustomImg
+        src={artworkUrl100}
+        borderRadius={20}
+        data-testid="album-songImage"
+        onClick={() => musicPlayer(index)}
+      />
       <CustomDiv>
         <CustomT data-testid="track-name" text={trackName} fontWeight={'bold'} />
         <If condition={trackExplicitness === 'explicit'}>

--- a/app/containers/ITunes/components/AlbumCard/index.js
+++ b/app/containers/ITunes/components/AlbumCard/index.js
@@ -35,8 +35,8 @@ const CustomT = styled(T)`
 `;
 export const AlbumCard = ({ artworkUrl100, trackName, trackExplicitness, artistName, index, musicPlayer }) => {
   return (
-    <CustomCard span={6} data-testid="album-card">
-      <CustomImg src={artworkUrl100} borderRadius={20} onClick={() => musicPlayer(index)} />
+    <CustomCard span={6} data-testid="album-card" onClick={() => musicPlayer(index)}>
+      <CustomImg src={artworkUrl100} borderRadius={20} />
       <CustomDiv>
         <CustomT data-testid="track-name" text={trackName} fontWeight={'bold'} />
         <If condition={trackExplicitness === 'explicit'}>

--- a/app/containers/ITunes/components/AlbumCard/index.js
+++ b/app/containers/ITunes/components/AlbumCard/index.js
@@ -33,10 +33,10 @@ const CustomT = styled(T)`
     font-size: ${(props) => props.fontSize}px;
   }
 `;
-export const AlbumCard = ({ artworkUrl100, trackName, trackExplicitness, artistName }) => {
+export const AlbumCard = ({ artworkUrl100, trackName, trackExplicitness, artistName, index, musicPlayer }) => {
   return (
     <CustomCard span={6} data-testid="album-card">
-      <CustomImg src={artworkUrl100} borderRadius={20} />
+      <CustomImg src={artworkUrl100} borderRadius={20} onClick={() => musicPlayer(index)} />
       <CustomDiv>
         <CustomT data-testid="track-name" text={trackName} fontWeight={'bold'} />
         <If condition={trackExplicitness === 'explicit'}>
@@ -55,7 +55,9 @@ AlbumCard.propTypes = {
   artworkUrl100: PropTypes.string,
   trackName: PropTypes.string,
   trackExplicitness: PropTypes.string,
-  artistName: PropTypes.string
+  artistName: PropTypes.string,
+  index: PropTypes.number,
+  musicPlayer: PropTypes.func
 };
 
 export default AlbumCard;

--- a/app/containers/ITunes/components/AlbumCard/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/ITunes/components/AlbumCard/tests/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ exports[`<AlbumCard /> tests should render and match the snapshot 1`] = `
     >
       <img
         class="AlbumCard__CustomImg-sc-1dt213m-1 TtZjZ"
+        data-testid="album-songImage"
       />
       <div
         class="AlbumCard__CustomDiv-sc-1dt213m-2 kfUBxP"

--- a/app/containers/ITunes/components/AlbumCard/tests/index.test.js
+++ b/app/containers/ITunes/components/AlbumCard/tests/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { renderWithIntl } from '@app/utils/testUtils';
+import { fireEvent } from '@testing-library/dom';
+import { renderProvider, renderWithIntl } from '@app/utils/testUtils';
 import AlbumCard from '../index';
-
 describe('<AlbumCard /> tests', () => {
   it('should render and match the snapshot', () => {
     const { baseElement } = renderWithIntl(<AlbumCard />);
@@ -17,5 +17,12 @@ describe('<AlbumCard /> tests', () => {
     const { getByTestId } = renderWithIntl(<AlbumCard trackName={trackName} artistName={artistName} />);
     expect(getByTestId('track-name')).toHaveTextContent(trackName);
     expect(getByTestId('artist-name')).toHaveTextContent(artistName);
+  });
+  it('should call musicPlayer with proper index after a album is clicked', () => {
+    const index = 1;
+    const musicPlayer = jest.fn();
+    const { getByTestId } = renderProvider(<AlbumCard index={index} musicPlayer={musicPlayer} />);
+    fireEvent.click(getByTestId('album-card'));
+    expect(musicPlayer).toBeCalledWith(index);
   });
 });

--- a/app/containers/ITunes/components/AlbumCard/tests/index.test.js
+++ b/app/containers/ITunes/components/AlbumCard/tests/index.test.js
@@ -22,7 +22,7 @@ describe('<AlbumCard /> tests', () => {
     const index = 1;
     const musicPlayer = jest.fn();
     const { getByTestId } = renderProvider(<AlbumCard index={index} musicPlayer={musicPlayer} />);
-    fireEvent.click(getByTestId('album-card'));
+    fireEvent.click(getByTestId('album-songImage'));
     expect(musicPlayer).toBeCalledWith(index);
   });
 });

--- a/app/containers/ITunes/components/PlayBack/index.js
+++ b/app/containers/ITunes/components/PlayBack/index.js
@@ -38,15 +38,16 @@ const PlayAlbumControl = styled.div`
 const PlayBack = ({ currentSong, setCurrentSong }) => {
   let audioRef = useRef('');
   return (
-    <PlayDiv>
+    <PlayDiv data-testid="playback-control">
       <PlayAlbumInfo>
         <img src={currentSong.img} />
-        <T text={currentSong.songName} style={{ marginLeft: '10px' }} />
+        <T text={currentSong.songName} data-testid="playback-songName" style={{ marginLeft: '10px' }} />
       </PlayAlbumInfo>
       <If
         condition={currentSong.play}
         otherwise={
           <PlayCircleFilled
+            data-testid="play"
             style={{ fontSize: '25px' }}
             onClick={() => {
               audioRef.current.play();
@@ -56,6 +57,7 @@ const PlayBack = ({ currentSong, setCurrentSong }) => {
         }
       >
         <PauseCircleFilled
+          data-testid="pause"
           style={{ fontSize: '25px' }}
           onClick={() => {
             audioRef.current.pause();
@@ -64,10 +66,17 @@ const PlayBack = ({ currentSong, setCurrentSong }) => {
         />
       </If>
       <PlayAlbumControl>
-        <Progress percent={currentSong.progress} status="active" size="small" showInfo={false} />
+        <Progress
+          data-testid="testProgress"
+          percent={currentSong.progress}
+          status="active"
+          size="small"
+          showInfo={false}
+        />
       </PlayAlbumControl>
       <audio
         autoPlay
+        data-testid="audioElement"
         src={currentSong.previewUrl}
         ref={audioRef}
         onEnded={() => setCurrentSong({ ...currentSong, play: false, progress: 0 })}

--- a/app/containers/ITunes/components/PlayBack/index.js
+++ b/app/containers/ITunes/components/PlayBack/index.js
@@ -1,0 +1,90 @@
+import React, { useRef } from 'react';
+import PropTypes from 'prop-types';
+import { PlayCircleFilled, PauseCircleFilled } from '@ant-design/icons';
+import T from '@components/T';
+import If from '@components/If';
+import { Progress } from 'antd';
+import styled from 'styled-components';
+
+const PlayDiv = styled.div`
+  && {
+    background: black;
+    color: white;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    position: fixed;
+    bottom: 0;
+    width: 690px;
+    border-radius: 10px 10px 0px 0px;
+    box-shadow: 0px 0px 10px 8px #888888;
+  }
+`;
+const PlayAlbumInfo = styled.div`
+  && {
+    display: flex;
+    align-items: center;
+    margin-left: 15px;
+  }
+`;
+const PlayAlbumControl = styled.div`
+  && {
+    width: 35%;
+    margin-right: 35px;
+  }
+`;
+
+const PlayBack = ({ currentSong, setCurrentSong }) => {
+  let audioRef = useRef('');
+  return (
+    <PlayDiv>
+      <PlayAlbumInfo>
+        <img src={currentSong.img} />
+        <T text={currentSong.songName} style={{ marginLeft: '10px' }} />
+      </PlayAlbumInfo>
+      <If
+        condition={currentSong.play}
+        otherwise={
+          <PlayCircleFilled
+            style={{ fontSize: '25px' }}
+            onClick={() => {
+              audioRef.current.play();
+              setCurrentSong({ ...currentSong, play: true });
+            }}
+          />
+        }
+      >
+        <PauseCircleFilled
+          style={{ fontSize: '25px' }}
+          onClick={() => {
+            audioRef.current.pause();
+            setCurrentSong({ ...currentSong, play: false });
+          }}
+        />
+      </If>
+      <PlayAlbumControl>
+        <Progress percent={currentSong.progress} status="active" size="small" showInfo={false} />
+      </PlayAlbumControl>
+      <audio
+        autoPlay
+        src={currentSong.previewUrl}
+        ref={audioRef}
+        onEnded={() => setCurrentSong({ ...currentSong, play: false, progress: 0 })}
+        onTimeUpdate={() =>
+          setCurrentSong({
+            ...currentSong,
+            progress: (audioRef.current.currentTime / audioRef.current.duration) * 100
+          })
+        }
+      />
+    </PlayDiv>
+  );
+};
+
+PlayBack.propTypes = {
+  currentSong: PropTypes.object,
+  setCurrentSong: PropTypes.func
+};
+
+export default PlayBack;

--- a/app/containers/ITunes/components/PlayBack/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/ITunes/components/PlayBack/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PlayBack /> tests should render and match the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="PlayBack__PlayDiv-sc-1aq47kd-0 htHHdB"
+      data-testid="playback-control"
+    >
+      <div
+        class="PlayBack__PlayAlbumInfo-sc-1aq47kd-1 gPVtut"
+      >
+        <img
+          src="test"
+        />
+        <p
+          class="T__StyledText-gjlic1-0 kYcyRq"
+          data-testid="playback-songName"
+          style="margin-left: 10px;"
+        >
+          test
+        </p>
+      </div>
+      <span
+        aria-label="play-circle"
+        class="anticon anticon-play-circle"
+        data-testid="play"
+        role="img"
+        style="font-size: 25px;"
+        tabindex="-1"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="play-circle"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm144.1 454.9L437.7 677.8a8.02 8.02 0 01-12.7-6.5V353.7a8 8 0 0112.7-6.5L656.1 506a7.9 7.9 0 010 12.9z"
+          />
+        </svg>
+      </span>
+      <div
+        class="PlayBack__PlayAlbumControl-sc-1aq47kd-2 jkHMCu"
+      >
+        <div
+          class="ant-progress ant-progress-line ant-progress-status-active ant-progress-small"
+          data-testid="testProgress"
+        >
+          <div
+            class="ant-progress-outer"
+          >
+            <div
+              class="ant-progress-inner"
+            >
+              <div
+                class="ant-progress-bg"
+                style="width: 0%; height: 6px;"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <audio
+        autoplay=""
+        data-testid="audioElement"
+      />
+    </div>
+  </div>
+</body>
+`;

--- a/app/containers/ITunes/components/PlayBack/tests/index.test.js
+++ b/app/containers/ITunes/components/PlayBack/tests/index.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { renderWithIntl } from '@app/utils/testUtils';
+import PlayBack from '../index';
+describe('<PlayBack /> tests', () => {
+  it('should render and match the snapshot', () => {
+    const song = { img: 'test', songName: 'test' };
+    const { baseElement } = renderWithIntl(<PlayBack currentSong={song} />);
+    expect(baseElement).toMatchSnapshot();
+  });
+  it('should render pause button when play=true', () => {
+    const song = { img: 'test', songName: 'test', play: true };
+    const { getByTestId } = renderWithIntl(<PlayBack currentSong={song} />);
+    expect(getByTestId('pause')).toBeInTheDocument();
+  });
+  it('should render play button when play=false', () => {
+    const song = { img: 'test', songName: 'test', play: false };
+    const { getByTestId } = renderWithIntl(<PlayBack currentSong={song} />);
+    expect(getByTestId('play')).toBeInTheDocument();
+  });
+});

--- a/app/containers/ITunes/index.js
+++ b/app/containers/ITunes/index.js
@@ -4,14 +4,14 @@
  *
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { createStructuredSelector } from 'reselect';
 import { compose } from 'redux';
 import { injectSaga } from 'redux-injectors';
-import { Card, Input, Row, Skeleton } from 'antd';
+import { Card, Input, Row, Skeleton, Progress } from 'antd';
 import { selectITunesData, selectITunesError, selectITunesName, selectITunesLoading } from './selectors';
 import saga from './saga';
 import styled from 'styled-components';
@@ -21,6 +21,7 @@ import If from '@components/If';
 import For from '@components/For';
 import T from '@components/T';
 import { AlbumCard } from './components/AlbumCard';
+import { PlayCircleFilled, PauseCircleFilled } from '@ant-design/icons';
 
 const { Search } = Input;
 const CustomCard = styled(Card)`
@@ -41,7 +42,34 @@ const Container = styled.div`
     padding: ${(props) => props.padding}px;
   }
 `;
-
+const PlayDiv = styled.div`
+  && {
+    background: black;
+    color: white;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    position: fixed;
+    bottom: 0;
+    width: 690px;
+    border-radius: 10px 10px 0px 0px;
+    box-shadow: 0px 0px 10px 8px #888888;
+  }
+`;
+const PlayAlbumInfo = styled.div`
+  && {
+    display: flex;
+    align-items: center;
+    margin-left: 15px;
+  }
+`;
+const PlayAlbumControl = styled.div`
+  && {
+    width: 35%;
+    margin-right: 35px;
+  }
+`;
 export function ITunes({
   intl,
   dispatchGetItunesData,
@@ -51,6 +79,14 @@ export function ITunes({
   iTunesError,
   loading
 }) {
+  const [currentSong, setCurrentSong] = useState({
+    songName: '',
+    img: '',
+    previewUrl: '',
+    play: false,
+    pause: true,
+    progress: 0
+  });
   useEffect(() => {
     if (iTunesName && !iTunesData?.results?.length) {
       dispatchGetItunesData(iTunesName);
@@ -65,13 +101,28 @@ export function ITunes({
     }
   };
   const debouncedHandleOnChange = debounce(handleOnChange, 200);
+  const musicPlayer = (index) => {
+    const selectedSong = iTunesData.results[index];
+    const songDetails = {
+      songName: selectedSong.trackName,
+      img: selectedSong.artworkUrl60,
+      previewUrl: selectedSong.previewUrl,
+      play: true,
+      pause: false
+    };
+    setCurrentSong(songDetails);
+  };
   const renderList = (iTunesData) => {
     const items = get(iTunesData, 'results', []);
     return (
       <If condition={!isEmpty(items) || loading}>
         <Skeleton loading={loading} active>
-          <Row gutter={[16, 16]} data-testid="dataRow">
-            <For of={items} noParent renderItem={(item, index) => <AlbumCard key={index} {...item} />} />
+          <Row gutter={[16, 16]} data-testid="dataRow" style={{ marginBottom: '60px' }}>
+            <For
+              of={items}
+              noParent
+              renderItem={(item, index) => <AlbumCard key={index} {...item} index={index} musicPlayer={musicPlayer} />}
+            />
           </Row>
         </Skeleton>
       </If>
@@ -84,7 +135,6 @@ export function ITunes({
     } else if (isEmpty(iTunesName)) {
       iTuneError = 'album_search_default';
     }
-
     return (
       !loading &&
       iTuneError && (
@@ -95,6 +145,55 @@ export function ITunes({
         </CustomCard>
       )
     );
+  };
+  const playSong = () => {
+    let audioRef = useRef('');
+    if (currentSong.songName) {
+      // console.log(audioRef.current.currentTime());
+      return (
+        <PlayDiv>
+          <PlayAlbumInfo>
+            <img src={currentSong.img} />
+            <T text={currentSong.songName} style={{ marginLeft: '10px' }} />
+          </PlayAlbumInfo>
+          <If
+            condition={currentSong.play}
+            otherwise={
+              <PlayCircleFilled
+                style={{ fontSize: '25px' }}
+                onClick={() => {
+                  audioRef.current.play();
+                  setCurrentSong({ ...currentSong, play: true });
+                }}
+              />
+            }
+          >
+            <PauseCircleFilled
+              style={{ fontSize: '25px' }}
+              onClick={() => {
+                audioRef.current.pause();
+                setCurrentSong({ ...currentSong, play: false });
+              }}
+            />
+          </If>
+          <PlayAlbumControl>
+            <Progress percent={currentSong.progress} status="active" size="small" showInfo={false} />
+          </PlayAlbumControl>
+          <audio
+            autoPlay
+            src={currentSong.previewUrl}
+            ref={audioRef}
+            onEnded={() => setCurrentSong({ ...currentSong, play: false, progress: 0 })}
+            onTimeUpdate={() =>
+              setCurrentSong({
+                ...currentSong,
+                progress: (audioRef.current.currentTime / audioRef.current.duration) * 100
+              })
+            }
+          />
+        </PlayDiv>
+      );
+    }
   };
   return (
     <Container maxwidth="700" padding="10">
@@ -110,6 +209,7 @@ export function ITunes({
       </CustomCard>
       {renderList(iTunesData)}
       {renderError()}
+      {playSong()}
     </Container>
   );
 }

--- a/app/containers/ITunes/index.js
+++ b/app/containers/ITunes/index.js
@@ -4,14 +4,14 @@
  *
  */
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { createStructuredSelector } from 'reselect';
 import { compose } from 'redux';
 import { injectSaga } from 'redux-injectors';
-import { Card, Input, Row, Skeleton, Progress } from 'antd';
+import { Card, Input, Row, Skeleton } from 'antd';
 import { selectITunesData, selectITunesError, selectITunesName, selectITunesLoading } from './selectors';
 import saga from './saga';
 import styled from 'styled-components';
@@ -21,7 +21,7 @@ import If from '@components/If';
 import For from '@components/For';
 import T from '@components/T';
 import { AlbumCard } from './components/AlbumCard';
-import { PlayCircleFilled, PauseCircleFilled } from '@ant-design/icons';
+import PlayBack from './components/PlayBack/index';
 
 const { Search } = Input;
 const CustomCard = styled(Card)`
@@ -40,34 +40,6 @@ const Container = styled.div`
     width: 100%;
     margin: 0 auto;
     padding: ${(props) => props.padding}px;
-  }
-`;
-const PlayDiv = styled.div`
-  && {
-    background: black;
-    color: white;
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    justify-content: space-between;
-    position: fixed;
-    bottom: 0;
-    width: 690px;
-    border-radius: 10px 10px 0px 0px;
-    box-shadow: 0px 0px 10px 8px #888888;
-  }
-`;
-const PlayAlbumInfo = styled.div`
-  && {
-    display: flex;
-    align-items: center;
-    margin-left: 15px;
-  }
-`;
-const PlayAlbumControl = styled.div`
-  && {
-    width: 35%;
-    margin-right: 35px;
   }
 `;
 export function ITunes({
@@ -146,55 +118,6 @@ export function ITunes({
       )
     );
   };
-  const playSong = () => {
-    let audioRef = useRef('');
-    if (currentSong.songName) {
-      // console.log(audioRef.current.currentTime());
-      return (
-        <PlayDiv>
-          <PlayAlbumInfo>
-            <img src={currentSong.img} />
-            <T text={currentSong.songName} style={{ marginLeft: '10px' }} />
-          </PlayAlbumInfo>
-          <If
-            condition={currentSong.play}
-            otherwise={
-              <PlayCircleFilled
-                style={{ fontSize: '25px' }}
-                onClick={() => {
-                  audioRef.current.play();
-                  setCurrentSong({ ...currentSong, play: true });
-                }}
-              />
-            }
-          >
-            <PauseCircleFilled
-              style={{ fontSize: '25px' }}
-              onClick={() => {
-                audioRef.current.pause();
-                setCurrentSong({ ...currentSong, play: false });
-              }}
-            />
-          </If>
-          <PlayAlbumControl>
-            <Progress percent={currentSong.progress} status="active" size="small" showInfo={false} />
-          </PlayAlbumControl>
-          <audio
-            autoPlay
-            src={currentSong.previewUrl}
-            ref={audioRef}
-            onEnded={() => setCurrentSong({ ...currentSong, play: false, progress: 0 })}
-            onTimeUpdate={() =>
-              setCurrentSong({
-                ...currentSong,
-                progress: (audioRef.current.currentTime / audioRef.current.duration) * 100
-              })
-            }
-          />
-        </PlayDiv>
-      );
-    }
-  };
   return (
     <Container maxwidth="700" padding="10">
       <CustomCard title={intl.formatMessage({ id: 'album_search' })}>
@@ -209,7 +132,9 @@ export function ITunes({
       </CustomCard>
       {renderList(iTunesData)}
       {renderError()}
-      {playSong()}
+      <If condition={currentSong.songName}>
+        <PlayBack currentSong={currentSong} setCurrentSong={setCurrentSong} />
+      </If>
     </Container>
   );
 }

--- a/app/containers/ITunes/tests/index.test.js
+++ b/app/containers/ITunes/tests/index.test.js
@@ -116,4 +116,43 @@ describe('<ITunes /> container tests', () => {
     // expect(getByTestId('error-message').textContent).toBe(iTunesError);
     expect(getByTestId('error-message')).toHaveTextContent(iTunesError);
   });
+  it('should show music playback after a album is clicked for the same album', async () => {
+    const trackName = 'test';
+    const iTunesData = { results: [{ trackName: trackName }] };
+    const { getByTestId } = renderProvider(<ITunes iTunesData={iTunesData} dispatchGetItunesData={submitSpy} />);
+    expect(getByTestId('dataRow')).toBeInTheDocument();
+    expect(getByTestId('album-card')).toBeInTheDocument();
+    await timeout(500);
+    fireEvent.click(getByTestId('album-card'));
+    expect(getByTestId('playback-control')).toBeInTheDocument();
+    expect(getByTestId('playback-songName')).toHaveTextContent(trackName);
+  });
+
+  it('should show play button when pause is clicked and pause button when play is clicked', async () => {
+    const trackName = 'test';
+    const iTunesData = { results: [{ trackName: trackName }] };
+    const { getByTestId } = renderProvider(<ITunes iTunesData={iTunesData} dispatchGetItunesData={submitSpy} />);
+
+    expect(getByTestId('dataRow')).toBeInTheDocument();
+    expect(getByTestId('album-card')).toBeInTheDocument();
+
+    await timeout(500);
+    fireEvent.click(getByTestId('album-card'));
+
+    expect(getByTestId('playback-control')).toBeInTheDocument();
+    expect(getByTestId('pause')).toBeInTheDocument();
+
+    fireEvent.click(getByTestId('pause'));
+
+    expect(getByTestId('play')).toBeInTheDocument();
+
+    fireEvent.click(getByTestId('play'));
+
+    expect(getByTestId('pause')).toBeInTheDocument();
+
+    expect(getByTestId('pause')).toBeInTheDocument();
+    const audioElement = getByTestId('audioElement');
+    audioElement.dispatchEvent(new Event('ended'));
+    expect(getByTestId('play')).toBeInTheDocument();
+  });
 });

--- a/app/containers/ITunes/tests/index.test.js
+++ b/app/containers/ITunes/tests/index.test.js
@@ -123,7 +123,7 @@ describe('<ITunes /> container tests', () => {
     expect(getByTestId('dataRow')).toBeInTheDocument();
     expect(getByTestId('album-card')).toBeInTheDocument();
     await timeout(500);
-    fireEvent.click(getByTestId('album-card'));
+    fireEvent.click(getByTestId('album-songImage'));
     expect(getByTestId('playback-control')).toBeInTheDocument();
     expect(getByTestId('playback-songName')).toHaveTextContent(trackName);
   });
@@ -137,7 +137,7 @@ describe('<ITunes /> container tests', () => {
     expect(getByTestId('album-card')).toBeInTheDocument();
 
     await timeout(500);
-    fireEvent.click(getByTestId('album-card'));
+    fireEvent.click(getByTestId('album-songImage'));
 
     expect(getByTestId('playback-control')).toBeInTheDocument();
     expect(getByTestId('pause')).toBeInTheDocument();

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "pre-commit": "lint:staged",
   "dependencies": {
+    "@ant-design/icons": "^4.7.0",
     "@babel/helper-regex": "^7.10.5",
     "@formatjs/intl-relativetimeformat": "^9.1.6",
     "@testing-library/jest-dom": "^5.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,11 @@
   resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz#480b025f4b20ef7fe8f47d4a4846e4fee84ea06c"
   integrity sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
 
+"@ant-design/icons-svg@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz#8630da8eb4471a4aabdaed7d1ff6a97dcb2cf05a"
+  integrity sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw==
+
 "@ant-design/icons@^4.6.2":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.6.2.tgz#290f2e8cde505ab081fda63e511e82d3c48be982"
@@ -28,6 +33,17 @@
   dependencies:
     "@ant-design/colors" "^6.0.0"
     "@ant-design/icons-svg" "^4.0.0"
+    "@babel/runtime" "^7.11.2"
+    classnames "^2.2.6"
+    rc-util "^5.9.4"
+
+"@ant-design/icons@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.7.0.tgz#8c3cbe0a556ba92af5dc7d1e70c0b25b5179af0f"
+  integrity sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==
+  dependencies:
+    "@ant-design/colors" "^6.0.0"
+    "@ant-design/icons-svg" "^4.2.1"
     "@babel/runtime" "^7.11.2"
     classnames "^2.2.6"
     rc-util "^5.9.4"


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description

- creates custom playback
- resets control once song playback is finished

---

### Steps to Reproduce / Test

---

---

### Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's
![iTunesPR5](https://user-images.githubusercontent.com/107981113/186169921-9e5ccb13-e867-4f79-958d-7ff7b54d0a8c.gif)

---

### Live Link

---

- http://wednesday-react-template.s3-website.ap-south-1.amazonaws.com/<BRANCH_NAME>
